### PR TITLE
Update local_sequential_store.js

### DIFF
--- a/src/modules/local_sequential_store.js
+++ b/src/modules/local_sequential_store.js
@@ -56,7 +56,7 @@ export default class LocalSequentialStore extends StatefulClass {
             const simplifiedResults = this.state.buffer
                 .filter(request => request.pageFunctionResult)
                 .map(simplifyResult)
-                .reduce((acc, result) => acc.concat(result));
+                .reduce((acc, result) => acc.concat(result),[]);
 
             logInfo(`SequentialStore: outputting file ${simplifiedKey}`);
             this._emitValue({


### PR DESCRIPTION
Add initial empty array to reduce method in _outputFile()  simplifiedResults, will this remove this exception?
 User function threw an exception:
2018-01-18T15:58:16.886Z TypeError: Reduce of empty array with no initial value
2018-01-18T15:58:16.888Z     at Array.reduce (<anonymous>)
2018-01-18T15:58:16.890Z     at LocalSequentialStore._outputFile (/home/node/build/modules/local_sequential_store.js:69:123)
2018-01-18T15:58:16.892Z     at LocalSequentialStore.destroy (/home/node/build/modules/local_sequential_store.js:83:44)
2018-01-18T15:58:16.894Z     at _apify2.default.main (/home/node/build/bootstrap.js:300:21)
2018-01-18T15:58:16.896Z     at <anonymous>